### PR TITLE
Fix provider mismatch crash

### DIFF
--- a/internal/meta/hcl_schema.go
+++ b/internal/meta/hcl_schema.go
@@ -23,7 +23,14 @@ func tuneHCLSchemaForResource(rb *hclwrite.Body, sch *schema.Schema) error {
 
 func tuneForBlock(rb *hclwrite.Body, sch *schema.SchemaBlock, parentAttrNames []string) error {
 	for attrName, attrVal := range rb.Attributes() {
-		schAttr := sch.Attributes[attrName]
+		schAttr, ok := sch.Attributes[attrName]
+		if !ok {
+			// This might because the provider under used is a newer one than the version where we ingest the schema information.
+			// This might happen when the user have some newer version provider installed in its local fs.
+			// We simply remove that attribute from the config.
+			rb.RemoveAttribute(attrName)
+			continue
+		}
 		if schAttr.Required {
 			continue
 		}


### PR DESCRIPTION
This might because the provider under used is a newer one than the version where we ingest the schema information.
This might happen when the user have some newer version provider installed in its local fs.
We simply remove that attribute from the config.